### PR TITLE
fix(track_helper): remove member variable re-definition

### DIFF
--- a/src/track_helper.cpp
+++ b/src/track_helper.cpp
@@ -464,7 +464,7 @@ void TrackHelper::draw_rect(const cv::Mat &cHp, cv::Mat & img, cv::Scalar color)
         corners[i].z = corners_hm.at<double>(2,i)/corners_hm.at<double>(3,i);
     }
 
-    cv::Mat rVec, tVec, distCoeffs;
+    cv::Mat rVec, tVec;
     rVec = cv::Mat::zeros(3,1,CV_32FC1); tVec = cv::Mat::zeros(3,1,CV_32FC1);
 	std::vector<cv::Point2f> corners_2d;
 


### PR DESCRIPTION
Remove useless variable re-definition that erase member `distCoeffs`.

Before:
![hybridmarker_shift](https://user-images.githubusercontent.com/15032112/69968448-bb10e100-151a-11ea-938b-e1ad3c2974c4.gif)

Now:
![hybridmarker_no_shift](https://user-images.githubusercontent.com/15032112/69968541-eabfe900-151a-11ea-8f22-d1851f2a8ece.gif)

Here is a sample video: https://owncloud.ircad.fr/index.php/s/FBUWVZ7Mk10YePX
and the associated calibration file: https://owncloud.ircad.fr/index.php/s/nJd1sTZmGP2F5Tt

Closes #7 